### PR TITLE
Add ATS enrichment (Ashby/Lever/Greenhouse + extras), fix YC regex, improve logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,38 @@
 # Changelog
 
+## [Unreleased]
+### Added
+- ATS enrichment subsystem
+  - Domain-specific HTML parsers wired via ATS handler registry.
+  - Currently supported:
+    - Ashby (jobs.ashbyhq.com, www.ashbyhq.com)
+    - Lever (jobs.lever.co)
+    - Greenhouse (boards.greenhouse.io)
+    - Work at a Startup (www.workatastartup.com)
+    - Deepnote careers (deepnote.com)
+- Expanded Ashby enrichment:
+  - Broader selector coverage (data-testid/class variants)
+  - Fallback to largest text block within main region
+  - Salary/remote heuristics
+- Enrichment debug logging:
+  - Prints handler selection, HTML length, and empty-description cases (first few items).
+
+### Changed
+- Hardened Ashby parser to improve description extraction across more tenants.
+- Minor normalization in text_collapse for cleaner line breaks/spaces.
+
+### Fixed
+- YCombinator crawler: replace ambiguous regex character class to remove warning.
+- Ensure source_key is set and tags are lists in crawlers to aid downstream enrichment.
+
+### TODO
+- Lightweight handler for YC company job pages
+  - Domain: www.ycombinator.com
+  - Paths: /companies/*/jobs/* (and optionally /companies/*/jobs)
+  - Extract visible description blocks; follow link-out when present
+  - Avoid nav/footer; add selectors for main content
+  - Register under ATS handler registry for domain=www.ycombinator.com
+
 ## [0.2.0] - 2025-08-28
 ### Added
 - Fresh, modular MCP server package `jobboard-mcp`.

--- a/scripts/test_job_service.py
+++ b/scripts/test_job_service.py
@@ -1,21 +1,47 @@
 import asyncio
+from collections import Counter
+from urllib.parse import urlparse
+
 from jobboard_mcp.tools.jobs import JobService
 
 async def main():
     async with JobService(cache_ttl_seconds=300) as svc:
         jobs = await svc.search_jobs(
             keywords=None,
-            sources=["hackernews_jobs"],  # isolate a single source first
+            sources=["hackernews_jobs", "ycombinator"],
             location="",
             remote_only=False,
             max_pages=1,
             per_source_limit=40,
+            enrich=True,
+            enrich_limit=10,
         )
+
         print("Fetched:", len(jobs))
-        if jobs:
-            sample = jobs[0].model_dump() if hasattr(jobs[0], "model_dump") else jobs[0].__dict__
-            print("Sample job:")
-            for k, v in sample.items():
+
+        if not jobs:
+            return
+
+        # Domain distribution of the first N jobs (to see what ATS we hit)
+        N = min(40, len(jobs))
+        domains = Counter(urlparse(j.url).netloc for j in jobs[:N] if getattr(j, "url", ""))
+        print("Top domains in first", N, "jobs:")
+        for dom, cnt in domains.most_common():
+            print(f"- {dom}: {cnt}")
+
+        # Show first 10 URLs and description lengths to verify enrichment
+        print("\nFirst 10 jobs (source_key, url, desc_len):")
+        for j in jobs[:10]:
+            print(j.source_key, j.url, "desc_len=", len(j.description or ""))
+
+        # Print a richer sample of the first job
+        print("\nSample job (first item):")
+        sample = jobs[0].__dict__
+        for k, v in sample.items():
+            if k == "description" and v:
+                preview = (v[:200] + "...") if len(v) > 200 else v
+                print(f"- {k}: {preview} (len={len(v)})")
+            else:
                 print(f"- {k}: {v}")
 
 if __name__ == "__main__":

--- a/src/jobboard_mcp/models/job.py
+++ b/src/jobboard_mcp/models/job.py
@@ -7,7 +7,7 @@ from typing import List, Optional
 class JobPosting:
     # Identity and provenance
     id: Optional[str] = None
-    source: str = ""
+    source: str = ""                 # Human-friendly source label, e.g., "Y Combinator"
 
     # Links
     url: str = ""
@@ -29,3 +29,6 @@ class JobPosting:
 
     # Raw content (optional)
     raw_html: Optional[str] = None
+
+    # New: internal routing key for JobService/crawlers (e.g., "ycombinator", "hackernews_jobs")
+    source_key: Optional[str] = None


### PR DESCRIPTION
### What

1. Introduces ATS enrichment subsystem with domain-specific handlers
2. Adds handlers: Ashby (incl. www alias), Lever, Greenhouse, Work at a Startup, Deepnote
3. Hardens Ashby parsing: broader selectors, largest-block fallback, salary/remote hints
4. Adds enrichment debug logs; minor text normalization
5. Ensures source_key and tag normalization across crawlers
6. Updates CHANGELOG with ATS section; adds TODO for YC company job pages

### Why

- Many YC/HN job links lacked descriptions. This improves coverage and observability.

### Testing

- Verified handler detection and non-empty desc_len on Ashby/Lever/Greenhouse pages
- Debug output shows handler=YES and html_len > 0 across sampled URLs

### TODO

- [ ] Implement lightweight handler for [www.ycombinator.com/companies/*/jobs/](http://www.ycombinator.com/companies/*/jobs/)