### PR TITLE
feat(mcp): scaffold parser registry, ParsedJob model, and parsing utils

### DIFF
--- a/src/jobboard_mcp/parsing/__init__.py
+++ b/src/jobboard_mcp/parsing/__init__.py
@@ -1,0 +1,19 @@
+from .models import ParsedJob, Section, SalaryInfo, CompanyProfile
+from .registry import ParserRegistry, Parser, DetectionResult
+from .utils import sanitize_html, normalize_text, extract_tech_stack, normalize_salary, guess_location
+
+__all__ = [
+    "ParsedJob",
+    "Section",
+    "SalaryInfo",
+    "CompanyProfile",
+    "ParserRegistry",
+    "Parser",
+    "DetectionResult",
+    "sanitize_html",
+    "normalize_text",
+    "extract_tech_stack",
+    "normalize_salary",
+    "guess_location",
+]
+

--- a/src/jobboard_mcp/parsing/models.py
+++ b/src/jobboard_mcp/parsing/models.py
@@ -1,0 +1,63 @@
+from dataclasses import dataclass, field
+from typing import List, Optional, Dict, Any
+
+
+@dataclass
+class Section:
+    heading: str
+    html: Optional[str] = None
+    text: Optional[str] = None
+
+
+@dataclass
+class SalaryInfo:
+    min: Optional[float] = None
+    max: Optional[float] = None
+    currency: Optional[str] = None
+    periodicity: Optional[str] = None  # e.g., year, hour, month
+    raw: Optional[str] = None
+
+
+@dataclass
+class CompanyProfile:
+    name: Optional[str] = None
+    tagline: Optional[str] = None
+    aboutHtml: Optional[str] = None
+    aboutText: Optional[str] = None
+    links: Dict[str, Optional[str]] = field(default_factory=dict)  # careers, website, linkedin, twitter
+    locations: List[str] = field(default_factory=list)
+
+
+@dataclass
+class ParsedJob:
+    # Core
+    id: Optional[str] = None
+    source: Optional[str] = None
+    url: Optional[str] = None
+    title: Optional[str] = None
+    company: Optional[str] = None
+    location: Optional[str] = None
+    postedDate: Optional[str] = None
+    salary: Optional[str] = None
+    jobType: Optional[str] = None
+    remoteOk: Optional[bool] = None
+    tags: List[str] = field(default_factory=list)
+
+    # Rich content
+    descriptionHtml: Optional[str] = None
+    descriptionText: Optional[str] = None
+    sections: List[Section] = field(default_factory=list)
+    salaryInfo: Optional[SalaryInfo] = None
+    requirements: List[str] = field(default_factory=list)
+    responsibilities: List[str] = field(default_factory=list)
+    benefits: List[str] = field(default_factory=list)
+    techStack: List[str] = field(default_factory=list)
+    seniority: Optional[str] = None
+    companyProfile: Optional[CompanyProfile] = None
+
+    # Provenance/meta
+    parser: Optional[str] = None  # yc_job, ashby_job, lever_job, greenhouse_job, generic_html, redirect_hub
+    contentScore: Optional[int] = None
+    warnings: List[str] = field(default_factory=list)
+    extra: Dict[str, Any] = field(default_factory=dict)
+

--- a/src/jobboard_mcp/parsing/registry.py
+++ b/src/jobboard_mcp/parsing/registry.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol, Optional, List, Tuple
+
+from bs4 import BeautifulSoup  # type: ignore
+
+from .models import ParsedJob
+
+
+@dataclass
+class DetectionResult:
+    score: int
+    reason: str
+
+
+class Parser(Protocol):
+    name: str
+
+    def detect(self, url: str, doc: BeautifulSoup) -> DetectionResult:
+        ...
+
+    def parse(self, url: str, doc: BeautifulSoup) -> ParsedJob:
+        ...
+
+
+class ParserRegistry:
+    def __init__(self) -> None:
+        self._parsers: List[Parser] = []
+
+    def register(self, parser: Parser) -> None:
+        self._parsers.append(parser)
+
+    def choose(self, url: str, doc: BeautifulSoup) -> Tuple[Parser, DetectionResult]:
+        best: Optional[Tuple[Parser, DetectionResult]] = None
+        for p in self._parsers:
+            try:
+                dr = p.detect(url, doc)
+            except Exception as e:
+                dr = DetectionResult(score=0, reason=f"detect error: {e}")
+            if best is None or dr.score > best[1].score:
+                best = (p, dr)
+        assert best is not None, "No parsers registered"
+        return best
+

--- a/src/jobboard_mcp/parsing/utils.py
+++ b/src/jobboard_mcp/parsing/utils.py
@@ -1,0 +1,67 @@
+import re
+from typing import List, Tuple
+
+from bs4 import BeautifulSoup  # type: ignore
+
+ALLOWED_TAGS = {"p", "ul", "ol", "li", "em", "strong", "br", "a", "h2", "h3"}
+
+
+def sanitize_html(html: str) -> str:
+    soup = BeautifulSoup(html, "html.parser")
+    for tag in soup.find_all(True):
+        if tag.name not in ALLOWED_TAGS:
+            tag.unwrap()
+        elif tag.name == "a":
+            # keep only href
+            attrs = {k: v for k, v in tag.attrs.items() if k == "href"}
+            tag.attrs = attrs
+        else:
+            tag.attrs = {}
+    return str(soup)
+
+
+def normalize_text(text: str) -> str:
+    # Fix common UTF-8 artifacts like â€¢ becoming •
+    text = text.replace("â€¢", "•")
+    text = re.sub(r"\s+", " ", text).strip()
+    return text
+
+
+_TECH_DICT = {
+    "typescript": "TypeScript",
+    "react": "React",
+    "node": "Node.js",
+    "python": "Python",
+    "java": "Java",
+    "aws": "AWS",
+    "gcp": "GCP",
+    "azure": "Azure",
+    "kubernetes": "Kubernetes",
+}
+
+
+def extract_tech_stack(text: str) -> List[str]:
+    lowered = text.lower()
+    found = []
+    for k, v in _TECH_DICT.items():
+        if k in lowered:
+            found.append(v)
+    return sorted(set(found))
+
+
+def normalize_salary(raw: str) -> Tuple[float, float, str, str]:
+    # Very simple regex-based extractor; to be improved.
+    # Returns (min, max, currency, periodicity)
+    m = re.search(r"\$\s*([0-9][0-9,]*)\s*-\s*\$\s*([0-9][0-9,]*)", raw)
+    if m:
+        mn = float(m.group(1).replace(",", ""))
+        mx = float(m.group(2).replace(",", ""))
+        return (mn, mx, "USD", "year")
+    return (0.0, 0.0, "", "")
+
+
+def guess_location(text: str) -> str:
+    if "remote" in text.lower():
+        return "Remote"
+    return "Unknown"
+


### PR DESCRIPTION
- Add ParsedJob model (fields per MCP_PARSING_DESIGN.md).
- Add parser registry interface and detection skeleton.
- Add shared utilities:
- HTML sanitizer
- Encoding/whitespace normalizer
- Tech stack dictionary/matcher
- Salary/location normalization helpers
- Add basic logging hooks (parser chosen, desc length, sections count).
- Add minimal unit tests using small HTML fixtures (snapshots ok).